### PR TITLE
fix: sorting by created at and updated at not working properly

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "editor.formatOnSave": false
-}

--- a/src/renderer/components/snippets/SnippetListItem.vue
+++ b/src/renderer/components/snippets/SnippetListItem.vue
@@ -14,9 +14,7 @@
     @contextmenu="onContext"
   >
     <div class="title">
-      <span>
-        {{ model.name }}
-      </span>
+      <span>{{ model.name }}</span>
     </div>
     <div class="meta">
       <div class="folder">
@@ -219,7 +217,7 @@ export default {
           label: 'Duplicate',
           click: () => {
             const snippet = Object.assign({}, this.model)
-            snippet.createAt = new Date()
+            snippet.createdAt = new Date()
             snippet.updatedAt = new Date()
             delete snippet._id
 
@@ -261,19 +259,19 @@ export default {
             {
               label: 'Date Modified',
               type: 'radio',
-              checked: this.sort === 'updateAt',
+              checked: this.sort === 'updatedAt',
               click: () => {
-                this.$store.dispatch('snippets/setSort', 'updateAt')
-                track('snippets/sort/updateAt')
+                this.$store.dispatch('snippets/setSort', 'updatedAt')
+                track('snippets/sort/updatedAt')
               }
             },
             {
               label: 'Date Created',
               type: 'radio',
-              checked: this.sort === 'createAt',
+              checked: this.sort === 'createdAt',
               click: () => {
-                this.$store.dispatch('snippets/setSort', 'createAt')
-                track('snippets/sort/createAt')
+                this.$store.dispatch('snippets/setSort', 'createdAt')
+                track('snippets/sort/createdAt')
               }
             },
             {

--- a/src/renderer/store/modules/snippets.js
+++ b/src/renderer/store/modules/snippets.js
@@ -28,7 +28,7 @@ export default {
           a.createdAt > b.createdAt ? -1 : 1
         )
       }
-      if (state.sort === 'updateAt') {
+      if (state.sort === 'updatedAt') {
         return [...state.snippets].sort((a, b) =>
           a.updatedAt > b.updatedAt ? -1 : 1
         )


### PR DESCRIPTION
Hey! I just found this project and loved it and wanted to contribute. I noticed that sorting by `created_at` and `updated_at` was not working properly due to incorrectly named props. 

Screencap of the bug: 

![Kapture 2020-03-10 at 12 43 53](https://user-images.githubusercontent.com/24225542/76309411-05012400-62cd-11ea-869b-31dcd42bbacd.gif)

This PR also adds a workspace setting to not formatOnSave as the formatter is not working nicely together with eslint specifically for this rule:

https://github.com/prettier/prettier/issues/3161

Looking forward do contribute!
_____


Thank you for your contribution to the massCode repo.
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] Your commits follow the [сonvention](https://github.com/antonreshetov/massCode/blob/master/.github/COMMIT_CONVENTION.md)

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `master` branch for v1.x
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)